### PR TITLE
FIP-22 create new PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@ Your PR title should be prefixed with the Jira ticket ID, e.g. "ADX-123 very imp
 ## Description
 
 Please include a summary of the change(s).
-You should also include motivation: why was this change required and what problem it solves.
+
+You should include a link to the JIRA ticket and also a sentence summary of the motivation.
 
 Don't forget to reference all other pull requests which are associated to this one below, especially if merging need to be coordinated.
 E.g.
@@ -14,12 +15,18 @@ relates fjelltopp/repository_name#issue_number
 
 ## Dependency Changes (delete if not applicable)
 
-List any dependencies that have been removed/added/changed in this pull request.
+List any dependencies that have been removed/added/changed in this pull request and explain why.
 Has the pipfile.lock or yarn.lock been updated?
+If dependency management for this project is centralised, e.g. `adx_deploy` for ADR, please link to the coordinated PR in the project repo.
 
 ## Testing (delete if not applicable)
 
-Please describe the new tests that have been added for this change along with any additional instructions required to reproduce a successful test and/or a list of any relevant details for your test configuration.
+Please describe the rationale behind any new tests that have been added for this change, e.g.
+
+- I have included automated unit tests for all features except V, because W
+- I have included automated integration tests for X that do Y
+- I have not included automated UI tests because Z
+- I have manually carried out the following tests that I have been unable to automate: A, B, C
 
 ## Documentation (delete if not applicable)
 
@@ -43,13 +50,12 @@ You may not need to check all boxes.
 
 - [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
 - [ ] I have developed these changes in discussion with the appropriate project manager.
-- [ ] Any UI changes have been approved by an appropriate project manager.
 - [ ] My code follows the general Fjelltopp documentation (see Confluence).
 - [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
 - [ ] I have rebased this branch with master.
 - [ ] New dependency changes have been committed.
-- [ ] New and existing unit tests pass locally with my changes.
+- [ ] I have added automated tests that prove my fix is effective or that my feature works.
+- [ ] New and existing tests pass locally with my changes.
 - [ ] My changes generate no new warnings.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have performed a self-review of my own code.
 - [ ] I have assigned at least one reviewer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+## Title (delete after following this rule)
+
+Your PR title should be prefixed with the Jira ticket ID, e.g. "ADX-123 very important feature".
+
+## Description
+
+Please include a summary of the change(s).
+You should also include motivation: why was this change required and what problem it solves.
+
+Don't forget to reference all other pull requests which are associated to this one below, especially if merging need to be coordinated.
+E.g.
+
+relates fjelltopp/repository_name#issue_number
+
+## Dependency Changes (delete if not applicable)
+
+List any dependencies that have been removed/added/changed in this pull request.
+Has the pipfile.lock or yarn.lock been updated?
+
+## Testing (delete if not applicable)
+
+Please describe the new tests that have been added for this change along with any additional instructions required to reproduce a successful test and/or a list of any relevant details for your test configuration.
+
+## Documentation (delete if not applicable)
+
+Please describe any new technical documentation that has been added to Confluence for this change.
+
+## Environment Changes (delete if not applicable)
+
+Have any environment variable changes been committed as part of this pull request?
+Is there a matching PR in fjelltopp/fjelltop-infrastructure for these changes?
+Have any README or Confluence install instructions been updated to reflect this change?
+
+## Internationalisation and Localisation (delete if not applicable)
+
+Do any UI changes require internationalisation (i18n) or localisation (l10n) changes.
+If new translations are required, have you created new Jira tickets for each language and informed the appropriate project manager?
+
+## Checklist
+
+Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
+You may not need to check all boxes.
+
+- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
+- [ ] I have developed these changes in discussion with the appropriate project manager.
+- [ ] Any UI changes have been approved by an appropriate project manager.
+- [ ] My code follows the general Fjelltopp documentation (see Confluence).
+- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
+- [ ] I have rebased this branch with master.
+- [ ] New dependency changes have been committed.
+- [ ] New and existing unit tests pass locally with my changes.
+- [ ] My changes generate no new warnings.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have assigned at least one reviewer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ Your PR title should be prefixed with the Jira ticket ID, e.g. "ADX-123 very imp
 ## Description
 
 Please include a summary of the change(s).
+You should also include screenshots or videos of UI changes.
 
 You should include a link to the JIRA ticket and also a sentence summary of the motivation.
 


### PR DESCRIPTION
This is my proposed PR template, it will basically autofill the PR when one is created in _any and all_ Fjelltopp repos. The expectation is then that people fill it out or delete the sections that aren't appropriate to their PR.

This will be explained as part of a "How we use GitHub" section in the Confluence document I am drafting.