### PR TITLE
feat: add new GitHub Issue templates :tada:

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/0_feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Request a new feature or an enhancement to an existing feature.
 title: "[Feature]: "
-labels: ["feature"]
+labels: ["enhancement"]
 projects: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/0_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/0_feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature Request
+description: Request a new feature or an enhancement to an existing feature.
+title: "[Feature]: "
+labels: ["feature"]
+projects: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Provide a clear and concise description of what the problem is, e.g. Our users are now requiring the ability to ... OR There is currently not a way for me as a user to ... .
+      placeholder: What problem are you trying to solve with this feature? What is the benefit for the user?
+      value: "Gee Brain, what are we gonna do tonight?"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Include a clear and concise description of what you want to happen, e.g. This will benefit users because ... . Include any code or visual designs - if applicable - that could help illustrate the idea
+      placeholder: Tell us what you think we should do
+      value: "The same thing we do every night, try to take over the world!"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Considerd Alternatives
+      description: A clear and concise description of any alternative solutions, ideas, code or design you've considered for this idea and why they were not selected.
+      placeholder: Tell us what you think we shouldn't do
+      value: "The irony of it all, Pinky. Years of trying to take over the world, and all I had to do was say 'moo'."

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+projects: []
+assignees: "ChasNelson1990"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        ⛔ Note: Before filling out this form, please search to see if an issue is already open or previously closed for the bug you have encountered to prevent duplication. ⛔
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see! And add screenshots!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: checkboxes
+    id: test
+    attributes:
+      label: Regression Test
+      description: Is a regression test required for this bug fix?
+      options:
+        - label: Of course it is!
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running? Please include the branch name and commit hash if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
## Description

As we are trailing using GitHub issues in @fjelltopp's [who-afro-dags](https://github.com/fjelltopp/who-afro-dags) repo, I thought I would create a couple of issue templates for Fjelltopp repos.

## Documentation

As this is still a pilot programme I have not added anything to general documentation; this can be done if we decide to make more wide spread migrations.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
